### PR TITLE
Bump nacl version and bump ncypher major version

### DIFF
--- a/lib/ncypher.rb
+++ b/lib/ncypher.rb
@@ -1,7 +1,6 @@
 require "ncypher/version"
 
 require "base64"
-require "rbnacl/libsodium"
 require "rbnacl/password_hash"
 
 require "rbnacl"

--- a/ncypher.gemspec
+++ b/ncypher.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 
-  spec.add_dependency 'rbnacl-libsodium', '~> 1.0'
   spec.add_dependency 'rbnacl', '~> 5.0'
 end

--- a/ncypher.gemspec
+++ b/ncypher.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.license       = 'WTFPL'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 


### PR DESCRIPTION
Update rbnacl. Now using the libsodium from the host instead.